### PR TITLE
Depths for nested items are not updated when parent items moves.

### DIFF
--- a/lib/nested_set/base.rb
+++ b/lib/nested_set/base.rb
@@ -28,6 +28,7 @@ module CollectiveIdea #:nodoc:
           # * +:parent_column+ - specifies the column name to use for keeping the position integer (default: parent_id)
           # * +:left_column+ - column name for left boundry data, default "lft"
           # * +:right_column+ - column name for right boundry data, default "rgt"
+          # * +:depth_column+ - column name for level cache data, default "depth"
           # * +:scope+ - restricts what is to be considered a list. Given a symbol, it'll attach "_id"
           #   (if it hasn't been already) and use that as the foreign key restriction. You
           #   can also pass an array to scope by multiple attributes.
@@ -45,6 +46,7 @@ module CollectiveIdea #:nodoc:
               :parent_column => 'parent_id',
               :left_column => 'lft',
               :right_column => 'rgt',
+              :depth_column => 'depth',
               :dependent => :delete_all, # or :destroy
             }.merge(options)
 
@@ -287,6 +289,10 @@ module CollectiveIdea #:nodoc:
             Array(acts_as_nested_set_options[:scope])
           end
 
+          def depth_column_name
+            acts_as_nested_set_options[:depth_column]
+          end
+
           def quoted_left_column_name
             connection.quote_column_name(left_column_name)
           end
@@ -301,6 +307,10 @@ module CollectiveIdea #:nodoc:
 
           def quoted_scope_column_names
             scope_column_names.collect {|column_name| connection.quote_column_name(column_name) }
+          end
+          
+          def quoted_depth_column_name
+            connection.quote_column_name(depth_column_name)            
           end
         end
 

--- a/lib/nested_set/depth.rb
+++ b/lib/nested_set/depth.rb
@@ -21,9 +21,12 @@ module CollectiveIdea #:nodoc:
 
         # Update cached_level attribute
         def update_depth
-          self.update_attribute(:depth, level)
+          depth_delta = level - depth 
+          if depth_delta != 0
+            self.self_and_descendants.update_all(["#{self.class.quoted_depth_column_name} = #{self.class.quoted_depth_column_name} + ?", depth_delta])
+          end
         end
-
+        
         # Update cached_level attribute for all record tree
         def update_all_depth
           if depth?

--- a/test/db/schema.rb
+++ b/test/db/schema.rb
@@ -6,6 +6,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.column :lft, :integer
     t.column :rgt, :integer
     t.column :organization_id, :integer
+    t.column :depth, :integer, :default => 0    
   end
 
   create_table :departments, :force => true do |t|
@@ -26,5 +27,6 @@ ActiveRecord::Schema.define(:version => 0) do
     t.column :mother_id, :integer
     t.column :red, :integer
     t.column :black, :integer
+    t.column :level, :integer
   end
 end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -14,32 +14,38 @@ top_level:
   name: Top Level
   lft: 1
   rgt: 10
+  depth: 0
 child_1:
   id: 2
   name: Child 1
   parent_id: 1
   lft: 2
   rgt: 3
+  depth: 1
 child_2:
   id: 3
   name: Child 2
   parent_id: 1
   lft: 4
   rgt: 7
+  depth: 1  
 child_2_1:
   id: 4
   name: Child 2.1
   parent_id: 3
   lft: 5
   rgt: 6
+  depth: 2  
 child_3:
   id: 5
   name: Child 3
   parent_id: 1
   lft: 8
   rgt: 9
+  depth: 1  
 top_level_2:
   id: 6
   name: Top Level 2
   lft: 11
   rgt: 12
+  depth: 0

--- a/test/nested_set_test.rb
+++ b/test/nested_set_test.rb
@@ -15,7 +15,7 @@ class ScopedCategory < ActiveRecord::Base
 end
 
 class RenamedColumns < ActiveRecord::Base
-  acts_as_nested_set :parent_column => 'mother_id', :left_column => 'red', :right_column => 'black'
+  acts_as_nested_set :parent_column => 'mother_id', :left_column => 'red', :right_column => 'black', :depth_column => 'level'
 end
 
 class NestedSetTest < ActiveSupport::TestCase
@@ -32,11 +32,15 @@ class NestedSetTest < ActiveSupport::TestCase
     assert_equal 'parent_id', Default.acts_as_nested_set_options[:parent_column]
   end
 
+  def test_depth_column_default
+    assert_equal 'depth', Default.acts_as_nested_set_options[:depth_column]
+  end
+
   def test_scope_default
     assert_nil Default.acts_as_nested_set_options[:scope]
   end
 
-  def test_left_column_name
+  def test_left_column_default
     assert_equal 'lft', Default.left_column_name
     assert_equal 'lft', Default.new.left_column_name
     assert_equal 'red', RenamedColumns.left_column_name
@@ -57,6 +61,13 @@ class NestedSetTest < ActiveSupport::TestCase
     assert_equal 'mother_id', RenamedColumns.new.parent_column_name
   end
 
+  def test_depth_column_name
+    assert_equal 'depth', Default.depth_column_name
+    assert_equal 'depth', Default.new.depth_column_name
+    assert_equal 'level', RenamedColumns.depth_column_name
+    assert_equal 'level', RenamedColumns.new.depth_column_name
+  end
+
   def test_creation_with_altered_column_names
     assert_nothing_raised do
       RenamedColumns.create!()
@@ -73,6 +84,12 @@ class NestedSetTest < ActiveSupport::TestCase
     quoted = Default.connection.quote_column_name('rgt')
     assert_equal quoted, Default.quoted_right_column_name
     assert_equal quoted, Default.new.quoted_right_column_name
+  end
+
+  def test_quoted_depth_column_name
+    quoted = Default.connection.quote_column_name('depth')
+    assert_equal quoted, Default.quoted_depth_column_name
+    assert_equal quoted, Default.new.quoted_depth_column_name
   end
 
   def test_left_column_protected_from_assignment
@@ -174,6 +191,24 @@ class NestedSetTest < ActiveSupport::TestCase
     assert_equal 2, categories(:child_2_1).level
   end
 
+  def test_depth
+    assert_equal 0, categories(:top_level).depth
+    assert_equal 1, categories(:child_1).depth
+    assert_equal 2, categories(:child_2_1).depth    
+  end
+
+  def test_depth_after_move
+    categories(:child_2).move_to_root
+
+    assert_equal 0, categories(:child_2).reload.depth    
+    assert_equal 1, categories(:child_2_1).reload.depth
+    
+    categories(:child_2).move_to_child_of(categories(:top_level_2))
+
+    assert_equal 1, categories(:child_2).reload.depth    
+    assert_equal 2, categories(:child_2_1).reload.depth
+  end
+  
   def test_has_children?
     assert categories(:child_2_1).children.empty?
     assert !categories(:child_2).children.empty?


### PR DESCRIPTION
nested_set did not update cached depths for nested items: only for an item which was moved.

Here is the failing test:

  def test_depth_after_move
    categories(:child_2).move_to_root

```
assert_equal 0, categories(:child_2).reload.depth    
assert_equal 1, categories(:child_2_1).reload.depth

categories(:child_2).move_to_child_of(categories(:top_level_2))

assert_equal 1, categories(:child_2).reload.depth    
assert_equal 2, categories(:child_2_1).reload.depth
```

  end

And there is a solution in my pull request.

Also, I have added :depth_column option. It may simplify migration from other tree plugins and useful when depth is used for something else.
