### PR TITLE
Found a bug in my fix

### DIFF
--- a/lib/nested_set/depth.rb
+++ b/lib/nested_set/depth.rb
@@ -22,6 +22,7 @@ module CollectiveIdea #:nodoc:
         # Update cached_level attribute
         def update_depth
           depth_delta = level - depth
+          self.depth += depth_delta
           if depth_delta != 0
             self.self_and_descendants.update_all(["#{self.class.quoted_depth_column_name} = #{self.class.quoted_depth_column_name} + ?", depth_delta])
           end

--- a/test/nested_set_test.rb
+++ b/test/nested_set_test.rb
@@ -209,6 +209,20 @@ class NestedSetTest < ActiveSupport::TestCase
     assert_equal 2, categories(:child_2_1).reload.depth
   end
 
+  def test_depth_after_moving_sequence
+    categories(:child_2).move_to_root
+
+    assert_equal 0, categories(:child_2).reload.depth
+    assert_equal 1, categories(:child_2_1).reload.depth
+
+    categories(:child_2).move_to_child_of(categories(:top_level_2))
+    categories(:child_1).move_to_child_of(categories(:top_level_2))
+    categories(:child_2).move_to_left_of(categories(:child_1))
+
+    assert_equal 1, categories(:child_2).reload.depth
+    assert_equal 2, categories(:child_2_1).reload.depth
+  end
+  
   def test_has_children?
     assert categories(:child_2_1).children.empty?
     assert !categories(:child_2).children.empty?


### PR DESCRIPTION
When item moves a few times during one request depth for item itself calculates incorrectly because I forget to refresh a depth column in moved object. Sorry.

Here is a failing test:

  def test_depth_after_moving_sequence
    categories(:child_2).move_to_root

```
assert_equal 0, categories(:child_2).reload.depth
assert_equal 1, categories(:child_2_1).reload.depth

categories(:child_2).move_to_child_of(categories(:top_level_2))
categories(:child_1).move_to_child_of(categories(:top_level_2))
categories(:child_2).move_to_left_of(categories(:child_1))

assert_equal 1, categories(:child_2).reload.depth
assert_equal 2, categories(:child_2_1).reload.depth
```

  end

Fixed.
