### PR TITLE
Support of custom destroy method

### DIFF
--- a/test/fixtures/category.rb
+++ b/test/fixtures/category.rb
@@ -24,3 +24,13 @@ end
 class Category_DefaultScope < Category
   default_scope order('categories.id ASC')
 end
+
+class Category_WithCustomDestroy < ActiveRecord::Base
+  set_table_name 'categories'
+  acts_as_nested_set
+
+  private :destroy
+  def custom_destroy
+    destroy
+  end
+end

--- a/test/nested_set_test.rb
+++ b/test/nested_set_test.rb
@@ -684,6 +684,17 @@ class NestedSetTest < ActiveSupport::TestCase
     assert Category.valid?
   end
 
+  def test_custom_destroy_method_does_not_invalidate
+    Category_WithCustomDestroy.acts_as_nested_set_options[:dependent] = :custom_destroy
+    Category_WithCustomDestroy.find_by_name('Child 2').custom_destroy
+    assert Category_WithCustomDestroy.valid?
+  end
+
+  def test_custom_destroy_raises_an_error_if_method_does_not_exist
+    Category.acts_as_nested_set_options[:dependent] = :custom_destroy
+    assert_raise(NoMethodError) { categories(:child_2).destroy }
+  end
+
   def test_assigning_parent_id_on_create
     category = Category.create!(:name => "Child", :parent_id => categories(:child_2).id)
     assert_equal categories(:child_2), category.parent


### PR DESCRIPTION
Hi Anton,

I've added a custom destroy method support to nested_set gem. 

In one of my projects I made the destroy method private, so it can't be called as model.destroy from the parent.
Instead, I use model.lazy_destroy, which can call or not the destroy method basing on the model state.
I also have important callbacks on destroy, and can't use :delete_all option for nested_set.

Could you merge this pull request and update the gem?  

Thanks,
Alex
