### PR TITLE
bug: if not default id column used

### DIFF
--- a/test/db/schema.rb
+++ b/test/db/schema.rb
@@ -1,6 +1,7 @@
 ActiveRecord::Schema.define(:version => 0) do
 
-  create_table :categories, :force => true do |t|
+  create_table :categories, :force => true, :id => false do |t|
+    t.primary_key :not_default_id_name
     t.column :name, :string
     t.column :parent_id, :integer
     t.column :lft, :integer

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -10,41 +10,41 @@
 #   top_level_2 --
 
 top_level:
-  id: 1
+  not_default_id_name: 1
   name: Top Level
   lft: 1
   rgt: 10
   #depth: NULL
 child_1:
-  id: 2
+  not_default_id_name: 2
   name: Child 1
   parent_id: 1
   lft: 2
   rgt: 3
   depth: 1
 child_2:
-  id: 3
+  not_default_id_name: 3
   name: Child 2
   parent_id: 1
   lft: 4
   rgt: 7
   depth: 1
 child_2_1:
-  id: 4
+  not_default_id_name: 4
   name: Child 2.1
   parent_id: 3
   lft: 5
   rgt: 6
   depth: 2
 child_3:
-  id: 5
+  not_default_id_name: 5
   name: Child 3
   parent_id: 1
   lft: 8
   rgt: 9
   depth: 1
 top_level_2:
-  id: 6
+  not_default_id_name: 6
   name: Top Level 2
   lft: 11
   rgt: 12

--- a/test/fixtures/category.rb
+++ b/test/fixtures/category.rb
@@ -1,4 +1,5 @@
 class Category < ActiveRecord::Base
+  set_primary_key :not_default_id_name
   acts_as_nested_set
   
   def to_s
@@ -22,11 +23,12 @@ class Category_NoToArray < Category
 end
 
 class Category_DefaultScope < Category
-  default_scope order('categories.id ASC')
+  default_scope order('categories.not_default_id_name ASC')
 end
 
 class Category_WithCustomDestroy < ActiveRecord::Base
   set_table_name 'categories'
+  set_primary_key :not_default_id_name
   acts_as_nested_set
 
   private :destroy

--- a/test/nested_set_test.rb
+++ b/test/nested_set_test.rb
@@ -6,11 +6,13 @@ end
 
 class Default < ActiveRecord::Base
   set_table_name 'categories'
+  set_primary_key :not_default_id_name
   acts_as_nested_set
 end
 
 class ScopedCategory < ActiveRecord::Base
   set_table_name 'categories'
+  set_primary_key :not_default_id_name
   acts_as_nested_set :scope => :organization
 end
 


### PR DESCRIPTION
I found a bug at base.rb:

```
      # Returns the array of all children and self
      def self_and_children
```
-              nested_set_scope.where("#{q_parent} = ? or id = ?", id, id)
-             nested_set_scope.where("#{q_parent} = :id or #{q_primary_key} = :id", :id => self)
        end

I propose to change id column name to be non default in fixtures for tests.
Thus it would prevent future errors of this kind.
