### PR TITLE
Fixed problem with updating depth while using different depth column

### DIFF
--- a/lib/nested_set/depth.rb
+++ b/lib/nested_set/depth.rb
@@ -34,7 +34,7 @@ module CollectiveIdea #:nodoc:
         # Update cached_level attribute for all record tree
         def update_all_depth
           if has_depth_column?
-            self.class.connection.execute("UPDATE #{self.class.quoted_table_name} a SET a.depth = \
+            self.class.connection.execute("UPDATE #{self.class.quoted_table_name} a SET a.#{self.class.quoted_depth_column_name} = \
                 (SELECT count(*) - 1 FROM (SELECT * FROM #{self.class.quoted_table_name} WHERE #{scope_condition}) AS b \
               	WHERE #{scope_condition('a')} AND \
               	(a.#{quoted_left_column_name} BETWEEN b.#{quoted_left_column_name} AND b.#{quoted_right_column_name}))

--- a/lib/nested_set/depth.rb
+++ b/lib/nested_set/depth.rb
@@ -22,7 +22,9 @@ module CollectiveIdea #:nodoc:
         # Update cached_level attribute
         def update_depth
           send :"#{depth_column_name}=", level
-          if depth_changed?
+          depth_changed = send :"#{depth_column_name}_changed?"
+          if depth_changed
+            depth_change = send :"#{depth_column_name}_change"
             self.self_and_descendants.
               update_all(["#{self.class.quoted_depth_column_name} = COALESCE(#{self.class.quoted_depth_column_name}, 0) + ?",
                 depth_change[1] - depth_change[0].to_i])


### PR DESCRIPTION
In one specific case, the updating of the depth value didn't work. The depth column was hardcoded, and was failing when another detph column name was used ('level' in my case). I changed it to use send :"#{depth_column_name}..." and it works as intended.
