### PR TITLE
Added option for tag to render_tree helper

### DIFF
--- a/lib/nested_set/helper.rb
+++ b/lib/nested_set/helper.rb
@@ -115,7 +115,9 @@ module CollectiveIdea #:nodoc:
         #
         def render_tree hash, options = {}, &block
           sort_proc = options.delete :sort
-          content_tag :ul, options do
+          tag = options.delete(:tag) || :ul
+
+          content_tag tag, options do
             hash.keys.sort_by(&sort_proc).each do |node|
               block.call node, render_tree(hash[node], :sort => sort_proc, &block)
             end


### PR DESCRIPTION
I think is a good idea allow the users (developers) decide which tag
should be used when render_tree is calling, so I implemented it by
passing tag option in options hash.
