### PR TITLE
Improving nested_set_option helper method to support query results (checking the 'each' support)

### DIFF
--- a/lib/nested_set/helper.rb
+++ b/lib/nested_set/helper.rb
@@ -29,7 +29,7 @@ module CollectiveIdea #:nodoc:
           items = case
           when class_or_items.is_a?(Class)
             class_or_items.roots
-          when class_or_items.is_a?(Array)
+          when class_or_items.respond_to?(:each)
             class_or_items
           else
             [class_or_items]

--- a/test/nested_set/helper_test.rb
+++ b/test/nested_set/helper_test.rb
@@ -18,7 +18,35 @@ class HelperTest < ActionView::TestCase
     end
     assert_equal expected, actual
   end
+  
+  def test_nested_set_options_from_a_query_with_roots_filter 
+    expected = [
+      [" Top Level", 1],
+	  ["- Child 1", 2],
+	  ["- Child 2", 3],
+	  ["-- Child 2.1", 4],
+	  ["- Child 3", 5],
+      [" Top Level 2", 6]
+    ]
+    actual = nested_set_options(Category.roots) do |c, level|
+      "#{'-' * level} #{c.name}"
+    end
+    assert_equal expected, actual
+  end
 
+  def test_nested_set_options_from_one_node 
+    expected = [
+      [" Top Level", 1],
+	  ["- Child 1", 2],
+	  ["- Child 2", 3],
+	  ["-- Child 2.1", 4],
+	  ["- Child 3", 5]
+    ]
+    actual = nested_set_options(Category.find 1) do |c, level|
+      "#{'-' * level} #{c.name}"
+    end
+    assert_equal expected, actual
+  end
   def test_nested_set_options_without_root
     expected = [
       [" Child 1", 2],


### PR DESCRIPTION
I have a structure Brand -> Categories, I would like to limit the options in the the `select` element to show the categories of the current brand, like this:

``` ruby
nested_set_options(@brand.categories.roots, @category) {|i, level| ....
```

with this result:

> NoMethodError: undefined method `self_and_descendants' for #ActiveRecord::Relation:0x007ff355abbdf0

the problem, simulating via rails console the flow in the ``nested_set_options` helper  was this:

``` ruby
1.9.3-p362 :019 >   b = Brand.find 1
1.9.3-p362 :020 > b.categories.roots.is_a? (Array)
 => false 
```

but

``` ruby
1.9.3-p362 :026 > b.categories.roots.respond_to?(:each)
 => true 
```

So I changed the helper to check the input 'each' support, instead of being an array.

Let me know if I'm missing something, thanks for your work!
